### PR TITLE
fix api uri + allowed space in prefix

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -1,5 +1,5 @@
 {
   "discordToken": "xxx",
   "discordPrefix": "!",
-  "apiUri": "https://api.warz.one"
+  "apiUri": "http://149.56.13.64:3000"
 }

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ client.on('ready', async () => {
 
 client.on('message', async (msg) => {
   if (msg.author.bot || msg.author.id == client.user.id) return;
-  const args = msg.content.slice(0).trim(config.discordPrefix.length).split(/ +/g);
+  const args = msg.content.slice(config.discordPrefix.length).trim().split(/ +/g);
   args.shift();
 
   if (msg.content.toLowerCase().startsWith(config.discordPrefix + 'player')) {


### PR DESCRIPTION
Previously, you would get "Invalid Player" when you tried to get a player and had a space in your prefix,
**EXAMPLE:**
```
war player MrScopes
```
 would return 'Invalid Player'
```
!player MrScopes
```
 would work. So, I fixed this so people can use spaces in the prefix.